### PR TITLE
support non-file urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -696,5 +696,5 @@ function urlToPath (u) {
 function urlToDirname (u) {
   return u.protocol === 'file:'
     ? path.dirname(url.fileURLToPath(u))
-    : decodeURI((new URL('.', u)).pathname).replace(/[^/]$/, '')
+    : decodeURIComponent((new URL('.', u)).pathname).replace(/\/$/, '')
 }


### PR DESCRIPTION
Right now when using `Module.load` with non file urls, you get the below error cause `bare-module` is using fileURLToPath for making the `filename` and `dirname` options for cjs. This fixes this by just "pretending" the pathname is the filename when using non file urls (ie unix paths).

```
Uncaught (in promise) URLError: INVALID_URL_SCHEME: The URL must use the file: protocol
    at Object.fileURLToPath (file:///Users/maf/dev/node_modules/pear2/node_modules/bare-url/index.js:195:18)
    at Module._extensions..cjs (file:///Users/maf/dev/node_modules/pear2/node_modules/bare-module/index.js:546:26)
    at Module._extensions..js (file:///Users/maf/dev/node_modules/pear2/node_modules/bare-module/index.js:518:51)
    at Module.load (file:///Users/maf/dev/node_modules/pear2/node_modules/bare-module/index.js:321:36)
    at Module._onimport (file:///Users/maf/dev/node_modules/pear2/node_modules/bare-module/index.js:202:25)
    at Module._evaluate (file:///Users/maf/dev/node_modules/pear2/node_modules/bare-module/index.js:126:13)
    at Module._transform (file:///Users/maf/dev/node_modules/pear2/node_modules/bare-module/index.js:117:12)
    at Module.load (file:///Users/maf/dev/node_modules/pear2/node_modules/bare-module/index.js:325:19)
    at module.exports (file:///Users/maf/dev/node_modules/pear2/lib/run.js:19:22)
```