### PR TITLE
Support platform and architecture conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Condition | Description
 `"node"` |
 `"import"` |
 `"require"` |
+`"<platform>"` |
+`"<arch>"` |
+`"simulator"` |
 `"default"` |
 
 ##### Self-referencing

--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ const Module = module.exports = exports = class Module {
   static _protocol = null
   static _cache = module.cache || Object.create(null)
   static _modules = new Set()
-  static _conditions = ['bare', 'node']
+  static _conditions = ['bare', 'node', Bare.platform, Bare.arch]
 
   static _handle = binding.init(this, this._onimport, this._onevaluate, this._onmeta)
 
@@ -596,6 +596,8 @@ const createRequire = exports.createRequire = function createRequire (parentURL,
     return addon._exports
   }
 }
+
+if (Bare.simulator) Module._conditions.push('simulator')
 
 Module._extensions['.js'] = function (module, source, referrer) {
   const self = Module

--- a/test.js
+++ b/test.js
@@ -1574,6 +1574,79 @@ test('conditional exports in package.json, array of conditions', (t) => {
   t.is(Module.resolve('/', new URL(root + '/'), { isImport: true, protocol }).href, root + '/foo.mjs')
 })
 
+test('conditional exports in package.json, runtime condition', (t) => {
+  t.teardown(onteardown)
+
+  const protocol = new Module.Protocol({
+    exists (url) {
+      return (
+        url.href === root + '/package.json' ||
+        url.href === root + '/foo.bare.js' ||
+        url.href === root + '/foo.node.js'
+      )
+    },
+
+    read (url) {
+      if (url.href === root + '/package.json') {
+        return '{ "exports": { "bare": "./foo.bare.js", "node": "./foo.node.js" } }'
+      }
+
+      t.fail()
+    }
+  })
+
+  t.is(Module.resolve('/', new URL(root + '/'), { protocol }).href, root + '/foo.bare.js')
+})
+
+test('conditional exports in package.json, platform condition', (t) => {
+  t.teardown(onteardown)
+
+  const protocol = new Module.Protocol({
+    exists (url) {
+      return (
+        url.href === root + '/package.json' ||
+        url.href === root + '/foo.darwin.js' ||
+        url.href === root + '/foo.linux.js' ||
+        url.href === root + '/foo.win32.js'
+      )
+    },
+
+    read (url) {
+      if (url.href === root + '/package.json') {
+        return '{ "exports": { "darwin": "./foo.darwin.js", "linux": "./foo.linux.js", "win32": "./foo.win32.js" } }'
+      }
+
+      t.fail()
+    }
+  })
+
+  t.is(Module.resolve('/', new URL(root + '/'), { protocol }).href, root + '/foo.' + Bare.platform + '.js')
+})
+
+test('conditional exports in package.json, architecture condition', (t) => {
+  t.teardown(onteardown)
+
+  const protocol = new Module.Protocol({
+    exists (url) {
+      return (
+        url.href === root + '/package.json' ||
+        url.href === root + '/foo.arm64.js' ||
+        url.href === root + '/foo.x64.js'
+      )
+    },
+
+    read (url) {
+      if (url.href === root + '/package.json') {
+        return '{ "exports": { "arm64": "./foo.arm64.js", "x64": "./foo.x64.js" } }'
+      }
+
+      t.fail()
+    }
+  })
+
+  t.is(Module.resolve('/', new URL(root + '/'), { protocol }).href, root + '/foo.' + Bare.arch + '.js')
+})
+
 test('exports in node_modules', (t) => {
   t.teardown(onteardown)
 


### PR DESCRIPTION
This allows packages to import and export modules using `Bare.platform`, `Bare.arch`, and `Bare.simulator` as conditions:

```json
{
  "exports": {
    ".": {
      "darwin": {
        "arm64": "./darwin-arm64.js",
        "x64": "./darwin-x64.js"
      },
      "ios": {
        "arm64": {
          "simulator": "./ios-arm64-simulator.js",
          "default": "./ios-arm64.js"
        },
        "x64": "./ios-x64-simulator.js"
      }
    }
  }
}
```

The primary use case of these conditions is compiled code such as native addon prebuilds.