### PR TITLE
Support `require()` attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ Options include:
   imports,
   resolutions,
   builtins,
-  conditions
+  conditions,
+  assertions
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Options include:
   resolutions,
   builtins,
   conditions,
-  assertions
+  attributes
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ const Module = module.exports = exports = class Module {
 
   static _handle = binding.init(this, this._onimport, this._onevaluate, this._onmeta)
 
-  static _onimport (href, assertions, referrerHref, isDynamicImport) {
+  static _onimport (href, attributes, referrerHref, isDynamicImport) {
     const referrer = this._cache[referrerHref] || null
 
     if (referrer === null) {
@@ -254,7 +254,7 @@ const Module = module.exports = exports = class Module {
 
     const url = this.resolve(href, referrer._url, { isImport: true, referrer })
 
-    const module = this.load(url, { isImport: true, isDynamicImport, referrer, assertions })
+    const module = this.load(url, { isImport: true, isDynamicImport, referrer, attributes })
 
     return module._handle
   }
@@ -360,8 +360,8 @@ const Module = module.exports = exports = class Module {
       isDynamicImport = false,
 
       referrer = null,
-      assertions,
-      type = typeForAssertions(assertions),
+      attributes,
+      type = typeForAttributes(attributes),
       defaultType = referrer ? referrer._defaultType : 0,
       cache = referrer ? referrer._cache : self._cache,
       main = referrer ? referrer._main : null,
@@ -534,10 +534,10 @@ function extensionForType (type) {
   }
 }
 
-function typeForAssertions (assertions) {
-  if (typeof assertions !== 'object' || assertions === null) return 0
+function typeForAttributes (attributes) {
+  if (typeof attributes !== 'object' || attributes === null) return 0
 
-  switch (assertions.type) {
+  switch (attributes.type) {
     case 'script':
       return constants.types.SCRIPT
     case 'module':
@@ -613,7 +613,7 @@ const createRequire = exports.createRequire = function createRequire (parentURL,
   function require (specifier, opts = {}) {
     const resolved = self.resolve(specifier, referrer._url, { referrer })
 
-    const module = self.load(resolved, { referrer, assertions: opts.with })
+    const module = self.load(resolved, { referrer, attributes: opts.with })
 
     return module._exports
   }

--- a/index.js
+++ b/index.js
@@ -212,8 +212,8 @@ const Module = module.exports = exports = class Module {
       this._run()
 
       this._exports = binding.getNamespace(this._handle)
-    } else {
-      if (eagerRun) this._run()
+    } else if (eagerRun) {
+      this._run()
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -1416,7 +1416,7 @@ test('import.meta', (t) => {
   t.comment(meta.addon.host)
 })
 
-test('import assertions', (t) => {
+test('import attributes', (t) => {
   t.teardown(onteardown)
 
   const protocol = new Module.Protocol({
@@ -1440,7 +1440,7 @@ test('import assertions', (t) => {
   t.alike(Module.load(new URL(root + '/foo.mjs'), { protocol }).exports.default, { hello: 'world' })
 })
 
-test('dynamic import assertions', async (t) => {
+test('dynamic import attributes', async (t) => {
   t.teardown(onteardown)
 
   const protocol = new Module.Protocol({
@@ -1464,7 +1464,7 @@ test('dynamic import assertions', async (t) => {
   t.comment(await Module.load(new URL(root + '/foo.mjs'), { protocol }).exports.default)
 })
 
-test('require assertions', (t) => {
+test('require attributes', (t) => {
   t.teardown(onteardown)
 
   const protocol = new Module.Protocol({

--- a/test.js
+++ b/test.js
@@ -1440,6 +1440,54 @@ test('import assertions', (t) => {
   t.alike(Module.load(new URL(root + '/foo.mjs'), { protocol }).exports.default, { hello: 'world' })
 })
 
+test('dynamic import assertions', async (t) => {
+  t.teardown(onteardown)
+
+  const protocol = new Module.Protocol({
+    exists (url) {
+      return url.href === root + '/bar'
+    },
+
+    read (url) {
+      if (url.href === root + '/foo.mjs') {
+        return 'export default import(\'/bar\', { with: { type: \'json\' } })'
+      }
+
+      if (url.href === root + '/bar') {
+        return '{ "hello": "world" }'
+      }
+
+      t.fail()
+    }
+  })
+
+  t.comment(await Module.load(new URL(root + '/foo.mjs'), { protocol }).exports.default)
+})
+
+test('require assertions', (t) => {
+  t.teardown(onteardown)
+
+  const protocol = new Module.Protocol({
+    exists (url) {
+      return url.href === root + '/bar'
+    },
+
+    read (url) {
+      if (url.href === root + '/foo.js') {
+        return 'module.exports = require(\'/bar\', { with: { type: \'json\' } })'
+      }
+
+      if (url.href === root + '/bar') {
+        return '{ "hello": "world" }'
+      }
+
+      t.fail()
+    }
+  })
+
+  t.alike(Module.load(new URL(root + '/foo.js'), { protocol }).exports, { hello: 'world' })
+})
+
 test('createRequire', (t) => {
   t.teardown(onteardown)
 


### PR DESCRIPTION
This makes `require()` a synchronous equivalent to `import()` with both supporting an `options` object as a second argument:

```js
require('./foo.json', { with: { type: 'json' } })
```

```js
await import('./foo.json', { with: { type: 'json' } })
```