### PR TITLE
Remove obsolete `protocol.load()` hook and add `module._source`

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,13 +635,6 @@ methods = {
   // A function that returns the source code of a URL represented as a string or
   // buffer.
   read,
-  // function (url): object
-  // A function that returns the evaluated exports for the url. This is
-  // only called for Javascript modules (extensions `.js`, `.cjs` & `.mjs`)
-  // by default. If defined, this function will skip calling `read()` and
-  // evaluating the source method for the default implementations of the
-  // Javascript extensions.
-  load,
   // function (url): URL
   // A function used to post process URLs for addons before `postresolve()`.
   addon,

--- a/binding.c
+++ b/binding.c
@@ -282,12 +282,8 @@ bare_module_create_function(js_env_t *env, js_callback_info_t *info) {
 
   js_value_t **args = malloc(sizeof(js_value_t *) * args_len);
 
-  uint32_t fetched;
-  err = js_get_array_elements(env, argv[1], args, args_len, 0, &fetched);
-
-  if (err < 0 || fetched != args_len) {
-    goto err;
-  }
+  err = js_get_array_elements(env, argv[1], args, args_len, 0, NULL);
+  if (err < 0) goto err;
 
   js_value_t *source = argv[2];
 
@@ -370,12 +366,8 @@ bare_module_create_synthetic_module(js_env_t *env, js_callback_info_t *info) {
 
   js_value_t **export_names = malloc(sizeof(js_value_t *) * names_len);
 
-  uint32_t fetched;
-  err = js_get_array_elements(env, argv[1], export_names, names_len, 0, &fetched);
-
-  if (err < 0 || fetched != names_len) {
-    goto err;
-  }
+  err = js_get_array_elements(env, argv[1], export_names, names_len, 0, NULL);
+  if (err < 0) goto err;
 
   bare_module_context_t *context;
   err = js_get_arraybuffer_info(env, argv[2], (void **) &context, NULL);

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,7 +5,6 @@ module.exports = {
     RUN: 4,
     DESTROYED: 8
   },
-
   types: {
     SCRIPT: 1,
     MODULE: 2,

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -6,7 +6,6 @@ module.exports = class ModuleProtocol {
       'resolve',
       'exists',
       'read',
-      'load',
       'addon',
       'asset'
     ]) {


### PR DESCRIPTION
Previously, module lexing relied on the ability to do `function.toString()` to get the module source, which isn't necessarily supported by the underlying JavaScript engine.