### PR TITLE
Support `imports` attribute for import mapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -446,6 +446,27 @@ module.exports = exports = class Module {
           module._builtins = builtins
           module._conditions = conditions
 
+          if (
+            typeof attributes === 'object' &&
+            attributes !== null &&
+            typeof attributes.imports === 'string'
+          ) {
+            const resolved = self.resolve(attributes.imports, url, {
+              referrer: module
+            })
+
+            const imports = self.load(resolved, {
+              referrer: module,
+              type: constants.types.JSON
+            })
+
+            module._imports = mixinImports(
+              module._imports,
+              imports._exports,
+              resolved
+            )
+          }
+
           let extension =
             canonicalExtensionForType(type) || path.extname(url.pathname)
 
@@ -685,6 +706,20 @@ function typeForAttributes(attributes) {
     default:
       return 0
   }
+}
+
+function mixinImports(target, imports, url) {
+  if (typeof imports === 'object' && imports !== null && 'imports' in imports) {
+    imports = imports.imports
+  }
+
+  if (typeof imports !== 'object' || imports === null) {
+    throw errors.INVALID_IMPORTS_MAP(
+      `Imports map at '${url.href}' is not valid`
+    )
+  }
+
+  return { ...target, ...imports }
 }
 
 exports.Protocol = Protocol

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -52,6 +52,14 @@ module.exports = class ModuleError extends Error {
     )
   }
 
+  static INVALID_IMPORTS_MAP(msg) {
+    return new ModuleError(
+      msg,
+      'INVALID_IMPORTS_MAP',
+      ModuleError.INVALID_IMPORTS_MAP
+    )
+  }
+
   static TYPE_INCOMPATIBLE(msg) {
     return new ModuleError(
       msg,

--- a/test.js
+++ b/test.js
@@ -3330,6 +3330,42 @@ test('load .js with imports attribute', (t) => {
   t.is(Module.load(new URL(root + '/foo.js'), { protocol }).exports, 42)
 })
 
+test('load .js with imports attribute, imports expansion', (t) => {
+  t.teardown(onteardown)
+
+  const protocol = new Module.Protocol({
+    exists(url) {
+      return (
+        url.href === root + '/bar.js' ||
+        url.href === root + '/baz.js' ||
+        url.href === root + '/imports.json'
+      )
+    },
+
+    read(url) {
+      if (url.href === root + '/foo.js') {
+        return "module.exports = require('./bar.js', { with: { imports: './imports.json' } })"
+      }
+
+      if (url.href === root + '/bar.js') {
+        return "module.exports = require('baz')"
+      }
+
+      if (url.href === root + '/baz.js') {
+        return 'module.exports = 42'
+      }
+
+      if (url.href === root + '/imports.json') {
+        return '{ "imports": { "baz": "/baz.js" } }'
+      }
+
+      t.fail()
+    }
+  })
+
+  t.is(Module.load(new URL(root + '/foo.js'), { protocol }).exports, 42)
+})
+
 test('load .js with imports attribute, invalid map', (t) => {
   t.teardown(onteardown)
 

--- a/test.js
+++ b/test.js
@@ -3320,7 +3320,7 @@ test('load .js with imports attribute', (t) => {
       }
 
       if (url.href === root + '/imports.json') {
-        return '{ "baz": "/baz.js" }'
+        return '{ "baz": "./baz.js" }'
       }
 
       t.fail()
@@ -3356,7 +3356,7 @@ test('load .js with imports attribute, imports expansion', (t) => {
       }
 
       if (url.href === root + '/imports.json') {
-        return '{ "imports": { "baz": "/baz.js" } }'
+        return '{ "imports": { "baz": "./baz.js" } }'
       }
 
       t.fail()
@@ -3425,7 +3425,7 @@ test('load .mjs with imports attribute', (t) => {
       }
 
       if (url.href === root + '/imports.json') {
-        return '{ "baz": "/baz.js" }'
+        return '{ "baz": "./baz.js" }'
       }
 
       t.fail()

--- a/test.js
+++ b/test.js
@@ -3294,6 +3294,75 @@ test('extend module with exports property', (t) => {
   }
 })
 
+test('load .js with imports attribute', (t) => {
+  t.teardown(onteardown)
+
+  const protocol = new Module.Protocol({
+    exists(url) {
+      return (
+        url.href === root + '/bar.js' ||
+        url.href === root + '/baz.js' ||
+        url.href === root + '/imports.json'
+      )
+    },
+
+    read(url) {
+      if (url.href === root + '/foo.js') {
+        return "module.exports = require('./bar.js', { with: { imports: './imports.json' } })"
+      }
+
+      if (url.href === root + '/bar.js') {
+        return "module.exports = require('baz')"
+      }
+
+      if (url.href === root + '/baz.js') {
+        return 'module.exports = 42'
+      }
+
+      if (url.href === root + '/imports.json') {
+        return '{ "baz": "/baz.js" }'
+      }
+
+      t.fail()
+    }
+  })
+
+  t.is(Module.load(new URL(root + '/foo.js'), { protocol }).exports, 42)
+})
+
+test('load .js with imports attribute, invalid map', (t) => {
+  t.teardown(onteardown)
+
+  const protocol = new Module.Protocol({
+    exists(url) {
+      return (
+        url.href === root + '/bar.js' ||
+        url.href === root + '/baz.js' ||
+        url.href === root + '/imports.json'
+      )
+    },
+
+    read(url) {
+      if (url.href === root + '/foo.js') {
+        return "module.exports = require('./bar.js', { with: { imports: './imports.json' } })"
+      }
+
+      if (url.href === root + '/imports.json') {
+        return '42'
+      }
+
+      t.fail()
+    }
+  })
+
+  try {
+    Module.load(new URL(root + '/foo.js'), { protocol })
+    t.fail()
+  } catch (err) {
+    t.comment(err.message)
+  }
+})
+
 function onteardown() {
   // TODO Provide a public API for clearing the cache.
   Module._cache = Object.create(null)


### PR DESCRIPTION
The new `imports` attribute allows a dependent module to mix in additional import mappings for dependency modules it imports. The additional mappings take precedence over any existing import mappings that apply for the dependent module and apply to all modules rooted at the subgraph of the dependency modules.

Consider, for example, a third-party module that imports `node:fs` without an appropriate import mapping when the module is imported from Bare:

```js
const fs = require('node:fs')

exports.doStuffWithFiles = function () { ... }
```

One way to use such a module from Bare today is to install `bare-fs` aliased as `fs` using https://github.com/holepunchto/bare-node. While this works fine for top-level application code, it breaks down when libraries are involved as the aliases then leak throughout the module tree. It's also only possible to alias non-npm modules, such as Node.js standard library modules, and so application code can't alias e.g. `node-fetch` to `bare-fetch` when used from third-party modules.

With the new `imports` attribute we can import the module above from Bare like this:

```js
const { doStuffWithFiles } = require('file-stuff-module', {
  with: { imports: './imports.json' }
});
```

`imports.json`
```json
{ "node:fs": "bare-fs" }
```

The `imports` attribute, like all other import attributes, must be a string literal as that's how the corresponding ES module grammar is defined. That also means that the above works the exact same way in an ES module:

```js
import { doStuffWithFiles } from 'file-stuff-module' with { imports: './imports.json' }
```