### PR TITLE
Allow extension of `Module` instances

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -62,9 +62,10 @@ class Module {
   constructor(url) {
     this._url = url
     this._state = 0
-    this._exports = null
     this._context = null
     this._promise = null
+
+    this.exports = null
   }
 
   get url() {
@@ -81,14 +82,6 @@ class Module {
 
   get main() {
     return this._context === null ? null : this._context.main
-  }
-
-  get exports() {
-    return this._exports
-  }
-
-  set exports(value) {
-    this._exports = value
   }
 
   get imports() {
@@ -253,7 +246,7 @@ class Module {
       if (url.protocol === 'builtin:') {
         module = cache[url.href] = new BuiltinModule(url)
 
-        module._exports = builtins[url.pathname]
+        module.exports = builtins[url.pathname]
       } else {
         let context
 
@@ -307,7 +300,7 @@ class Module {
           })
 
           module._context = module._context.fork({
-            imports: mixinImports(module._context.imports, imports._exports, resolved)
+            imports: mixinImports(module._context.imports, imports.exports, resolved)
           })
         }
 
@@ -501,13 +494,13 @@ class Module {
 
       if (
         name === 'default' &&
-        (typeof module._exports !== 'object' ||
-          module._exports === null ||
-          name in module._exports === false)
+        (typeof module.exports !== 'object' ||
+          module.exports === null ||
+          name in module.exports === false)
       ) {
-        value = module._exports
+        value = module.exports
       } else {
-        value = module._exports[name]
+        value = module.exports[name]
       }
 
       binding.setModuleExport(module, name, value)
@@ -541,7 +534,7 @@ class Module {
 
       const addon = Bare.Addon.load(resolved, { referrer })
 
-      return addon._exports
+      return addon.exports
     }
 
     meta.addon.resolve = function resolve(specifier = '.', parentURL = referrer._url) {
@@ -631,7 +624,7 @@ exports.createRequire = function createRequire(parentURL, opts = {}) {
 
     const module = Module.load(resolved, { referrer, attributes })
 
-    return module._exports
+    return module.exports
   }
 
   require.main = module._context.main
@@ -646,7 +639,7 @@ exports.createRequire = function createRequire(parentURL, opts = {}) {
 
     const addon = Bare.Addon.load(resolved, { referrer })
 
-    return addon._exports
+    return addon.exports
   }
 
   require.addon.host = Bare.Addon.host
@@ -694,7 +687,7 @@ function resolutionsFor(opts, fallback = Object.create(null)) {
 function readPackageFor(protocol, cache) {
   return function readPackage(packageURL) {
     if (protocol.exists(packageURL, constants.types.JSON)) {
-      return Module.load(packageURL, { protocol, cache })._exports
+      return Module.load(packageURL, { protocol, cache }).exports
     }
 
     return null
@@ -848,7 +841,7 @@ function isESModuleScope(url, context) {
     }
   }
 
-  const info = (pkg && pkg._exports) || {}
+  const info = (pkg && pkg.exports) || {}
 
   return (
     // The default type is ES modules.

--- a/lib/module/addon.js
+++ b/lib/module/addon.js
@@ -3,17 +3,11 @@ const SyntheticModule = require('./synthetic')
 
 // A native addon module, whose exports are provided by the addon subsystem.
 module.exports = class AddonModule extends SyntheticModule {
-  constructor(url) {
-    super(url)
-
-    Object.preventExtensions(this)
-  }
-
   get type() {
     return constants.types.ADDON
   }
 
   _initialize(source, referrer) {
-    this._exports = Bare.Addon.load(this._url, { referrer: this }).exports
+    this.exports = Bare.Addon.load(this._url, { referrer: this }).exports
   }
 }

--- a/lib/module/binary.js
+++ b/lib/module/binary.js
@@ -3,12 +3,6 @@ const ValueModule = require('./value')
 
 // A binary module, whose default export is its source as a buffer.
 module.exports = class BinaryModule extends ValueModule {
-  constructor(url) {
-    super(url)
-
-    Object.preventExtensions(this)
-  }
-
   get type() {
     return constants.types.BINARY
   }

--- a/lib/module/builtin.js
+++ b/lib/module/builtin.js
@@ -2,10 +2,4 @@ const SyntheticModule = require('./synthetic')
 
 // A builtin module, whose exports are provided directly by the host through the
 // builtins map. It has no type of its own and exposes only a default export.
-module.exports = class BuiltinModule extends SyntheticModule {
-  constructor(url) {
-    super(url)
-
-    Object.preventExtensions(this)
-  }
-}
+module.exports = class BuiltinModule extends SyntheticModule {}

--- a/lib/module/bundle.js
+++ b/lib/module/bundle.js
@@ -12,8 +12,6 @@ module.exports = class BundleModule extends SyntheticModule {
     super(url)
 
     this._bundle = null
-
-    Object.preventExtensions(this)
   }
 
   get type() {
@@ -56,9 +54,9 @@ module.exports = class BundleModule extends SyntheticModule {
     const bundle = this._bundle
 
     if (bundle.main) {
-      this._exports = Module.load(new URL(bundle.main), bundle.read(bundle.main), {
+      this.exports = Module.load(new URL(bundle.main), bundle.read(bundle.main), {
         referrer: this
-      })._exports
+      }).exports
     }
   }
 

--- a/lib/module/commonjs.js
+++ b/lib/module/commonjs.js
@@ -18,8 +18,6 @@ module.exports = class CommonJSModule extends SyntheticModule {
 
     this._source = null
     this._function = null
-
-    Object.preventExtensions(this)
   }
 
   get type() {
@@ -48,11 +46,11 @@ module.exports = class CommonJSModule extends SyntheticModule {
 
     const require = Module.createRequire(this._url, { module: this })
 
-    this._exports = {}
+    this.exports = {}
 
     const fn = this._function // Bind to variable to ensure proper stack trace
 
-    fn(require, this, this._exports, urlToPath(this._url), urlToDirname(this._url))
+    fn(require, this, this.exports, urlToPath(this._url), urlToDirname(this._url))
   }
 
   // A script module contributes the export names found by lexing its source,

--- a/lib/module/esm.js
+++ b/lib/module/esm.js
@@ -10,8 +10,6 @@ module.exports = class ESModule extends Module {
     super(url)
 
     this._source = null
-
-    Object.preventExtensions(this)
   }
 
   get type() {
@@ -37,7 +35,7 @@ module.exports = class ESModule extends Module {
 
     this._run()
 
-    this._exports = binding.getModuleNamespace(this)
+    this.exports = binding.getModuleNamespace(this)
   }
 
   _exportNames(names, queue) {

--- a/lib/module/json.js
+++ b/lib/module/json.js
@@ -3,12 +3,6 @@ const ValueModule = require('./value')
 
 // A JSON module, whose exports are the parsed JSON value.
 module.exports = class JSONModule extends ValueModule {
-  constructor(url) {
-    super(url)
-
-    Object.preventExtensions(this)
-  }
-
   get type() {
     return constants.types.JSON
   }
@@ -20,6 +14,6 @@ module.exports = class JSONModule extends ValueModule {
   // A JSON module additionally exposes each of its top-level keys as a named
   // export.
   _exportNames(names) {
-    for (const name of Object.keys(this._exports)) names.add(name)
+    for (const name of Object.keys(this.exports)) names.add(name)
   }
 }

--- a/lib/module/text.js
+++ b/lib/module/text.js
@@ -3,12 +3,6 @@ const ValueModule = require('./value')
 
 // A text module, whose default export is its source decoded as a string.
 module.exports = class TextModule extends ValueModule {
-  constructor(url) {
-    super(url)
-
-    Object.preventExtensions(this)
-  }
-
   get type() {
     return constants.types.TEXT
   }

--- a/lib/module/value.js
+++ b/lib/module/value.js
@@ -6,7 +6,7 @@ const { readSource } = require('../helpers')
 // no separate evaluation step.
 module.exports = class ValueModule extends SyntheticModule {
   _initialize(source) {
-    this._exports = this._parse(readSource(this, source))
+    this.exports = this._parse(readSource(this, source))
   }
 
   _parse(source) {

--- a/test.js
+++ b/test.js
@@ -3191,12 +3191,7 @@ test('extend module with exports property', (t) => {
     }
   })
 
-  try {
-    Module.load(new URL(root + '/foo.js'), { protocol, cache: false })
-    t.fail()
-  } catch (err) {
-    t.comment(err.message)
-  }
+  Module.load(new URL(root + '/foo.js'), { protocol, cache: false })
 })
 
 test('load .js with imports attribute', (t) => {


### PR DESCRIPTION
The move to `js_wrap()`, which is required for the upcoming snapshot feature in https://github.com/holepunchto/libjs/pull/39, causes `Object.preventExtensions(this)` to break the wrapping in engine bindings where `js_wrap()` is backed by normal JavaScript properties instead of opaque private data. One such case is JavaScriptCore: https://github.com/holepunchto/libjsc/blob/0efae7e63824eff1a298a9845b44cc044c169726/src/js.c#L1346-L1377