### PR TITLE
Don't provide direct file system access

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,14 @@ foo.exports(2, 3)
 // 5
 ```
 
-To resolve and load specifiers relative to a directory, as `require()` does, create a `require()` bound to a parent URL:
+To resolve and load specifiers relative to a directory, as `require()` does, create a `require()` bound to a parent URL. The default protocol has no backing store of its own and cannot read from the file system, so pass a [protocol](#protocols) that serves the source:
 
 ```js
 const Module = require('bare-module')
 
-const require = Module.createRequire('file:///directory/')
+const require = Module.createRequire('file:///directory/', { protocol })
 
-// Resolves and loads `file:///directory/foo.js`, reading it through the
-// default protocol.
+// Resolves and loads `file:///directory/foo.js`, reading it through `protocol`.
 const foo = require('./foo.js')
 ```
 
@@ -308,11 +307,11 @@ The flags for the current state of a module.
 
 #### `Module.protocol`
 
-The default `ModuleProtocol` class for resolving, reading and loading modules. See [Protocols](#protocols) for usage.
+The default `ModuleProtocol` instance. It has no capabilities of its own; in particular, it cannot read from the file system. To serve modules from a backing store, provide your own protocol. See [Protocols](#protocols) for usage.
 
 #### `Module.cache`
 
-The global cache of loaded modules.
+The shared cache of loaded modules. Use of this cache is opt-in: pass `cache: true` to load a module into it.
 
 #### `const url = Module.resolve(specifier, parentURL[, options])`
 
@@ -399,8 +398,11 @@ options = {
   // such as `.js`. See Module.constants.types. Inherited from `referrer` if it
   // is defined.
   defaultType: Module.constants.types.SCRIPT,
-  // Cache to use to load the Module. Defaults to `Module.cache`. Pass `false`
-  // to use a throw-away cache scoped to this load and its module graph.
+  // Cache to use to load the Module. When left unspecified, the cache is
+  // inherited from `referrer` so a module graph shares a single cache,
+  // otherwise a fresh cache scoped to this load and its graph is used. Pass
+  // an explicit cache object to use it, `true` to opt in to the shared
+  // `Module.cache`, or `false` to force a fresh cache.
   cache,
   // The module representing the entry script where the program was launched.
   main,
@@ -616,7 +618,8 @@ options = {
   // is defined, otherwise defaults to SCRIPT.
   defaultType: Module.constants.types.SCRIPT,
   // A cache of loaded modules. Inherited from `referrer` if it is defined,
-  // otherwise defaults to `Module.cache`. Pass `false` to use a throw-away
+  // otherwise a fresh cache is used. Pass an explicit cache object to use it,
+  // `true` to opt in to the shared `Module.cache`, or `false` to force a fresh
   // cache.
   cache,
   // The module representing the entry script where the program was launched.

--- a/binding.c
+++ b/binding.c
@@ -6,7 +6,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <utf.h>
-#include <uv.h>
 
 typedef struct {
   js_env_t *env;
@@ -516,169 +515,6 @@ bare_module_get_module_namespace(js_env_t *env, js_callback_info_t *info) {
 }
 
 static js_value_t *
-bare_module_exists(js_env_t *env, js_callback_info_t *info) {
-  int err;
-
-  uv_loop_t *loop;
-  err = js_get_env_loop(env, &loop);
-  assert(err == 0);
-
-  js_value_t *argv[2];
-  size_t argc = 2;
-
-  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
-  assert(err == 0);
-
-  assert(argc == 2);
-
-  utf8_t path[4096];
-  err = js_get_value_string_utf8(env, argv[0], path, 4096, NULL);
-  assert(err == 0);
-
-  uint32_t mode;
-  err = js_get_value_uint32(env, argv[1], &mode);
-  assert(err == 0);
-
-  uv_fs_t req;
-  uv_fs_stat(loop, &req, (char *) path, NULL);
-
-  uv_stat_t *st = req.result < 0 ? NULL : req.ptr;
-
-  js_value_t *result;
-  err = js_get_boolean(env, st && st->st_mode & mode, &result);
-  assert(err == 0);
-
-  uv_fs_req_cleanup(&req);
-
-  return result;
-}
-
-static js_value_t *
-bare_module_realpath(js_env_t *env, js_callback_info_t *info) {
-  int err;
-
-  uv_loop_t *loop;
-  err = js_get_env_loop(env, &loop);
-  assert(err == 0);
-
-  js_value_t *argv[1];
-  size_t argc = 1;
-
-  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
-  assert(err == 0);
-
-  assert(argc == 1);
-
-  utf8_t path[4096];
-  err = js_get_value_string_utf8(env, argv[0], path, 4096, NULL);
-  assert(err == 0);
-
-  uv_fs_t req;
-  uv_fs_realpath(loop, &req, (char *) path, NULL);
-
-  int res = req.result;
-
-  if (res < 0) {
-    uv_fs_req_cleanup(&req);
-    err = res;
-    goto err;
-  }
-
-  js_value_t *result;
-  err = js_create_string_utf8(env, (utf8_t *) req.ptr, -1, &result);
-  assert(err == 0);
-
-  uv_fs_req_cleanup(&req);
-
-  return result;
-
-err:
-  err = js_throw_error(env, uv_err_name(err), uv_strerror(err));
-  assert(err == 0);
-
-  return NULL;
-}
-
-static js_value_t *
-bare_module_read(js_env_t *env, js_callback_info_t *info) {
-  int err;
-
-  uv_loop_t *loop;
-  err = js_get_env_loop(env, &loop);
-  assert(err == 0);
-
-  js_value_t *argv[1];
-  size_t argc = 1;
-
-  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
-  assert(err == 0);
-
-  assert(argc == 1);
-
-  utf8_t path[4096];
-  err = js_get_value_string_utf8(env, argv[0], path, 4096, NULL);
-  assert(err == 0);
-
-  uv_fs_t req;
-  uv_fs_open(loop, &req, (char *) path, UV_FS_O_RDONLY, 0, NULL);
-
-  int fd = req.result;
-  uv_fs_req_cleanup(&req);
-
-  if (fd < 0) {
-    err = fd;
-    goto err;
-  }
-
-  uv_fs_fstat(loop, &req, fd, NULL);
-  uv_stat_t *st = req.ptr;
-
-  size_t len = st->st_size;
-  char *base;
-
-  js_value_t *result;
-  err = js_create_arraybuffer(env, len, (void **) &base, &result);
-  assert(err == 0);
-
-  uv_buf_t buffer = uv_buf_init(base, len);
-
-  uv_fs_req_cleanup(&req);
-
-  int64_t read = 0;
-
-  while (true) {
-    uv_fs_read(loop, &req, fd, &buffer, 1, read, NULL);
-
-    int res = req.result;
-    uv_fs_req_cleanup(&req);
-
-    if (res < 0) {
-      uv_fs_close(loop, &req, fd, NULL);
-      uv_fs_req_cleanup(&req);
-      err = res;
-      goto err;
-    }
-
-    buffer.base += res;
-    buffer.len -= res;
-
-    read += res;
-    if (res == 0 || read == len) break;
-  }
-
-  uv_fs_close(loop, &req, fd, NULL);
-  uv_fs_req_cleanup(&req);
-
-  return result;
-
-err:
-  err = js_throw_error(env, uv_err_name(err), uv_strerror(err));
-  assert(err == 0);
-
-  return NULL;
-}
-
-static js_value_t *
 bare_module_exports(js_env_t *env, js_value_t *exports) {
   int err;
 
@@ -701,23 +537,6 @@ bare_module_exports(js_env_t *env, js_value_t *exports) {
   V("setModuleExport", bare_module_set_module_export)
   V("runModule", bare_module_run_module)
   V("getModuleNamespace", bare_module_get_module_namespace)
-
-  V("exists", bare_module_exists)
-  V("realpath", bare_module_realpath)
-  V("read", bare_module_read)
-#undef V
-
-#define V(name, n) \
-  { \
-    js_value_t *val; \
-    err = js_create_uint32(env, n, &val); \
-    assert(err == 0); \
-    err = js_set_named_property(env, exports, name, val); \
-    assert(err == 0); \
-  }
-
-  V("FILE", S_IFREG)
-  V("DIR", S_IFDIR)
 #undef V
 
   return exports;

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,6 +1,6 @@
 const path = require('bare-path')
 const resolve = require('bare-module-resolve')
-const { isURL, fileURLToPath, pathToFileURL } = require('bare-url')
+const { isURL, pathToFileURL } = require('bare-url')
 const Bundle = require('bare-bundle')
 const ModuleProtocol = require('./protocol')
 const ModuleContext = require('./context')
@@ -14,38 +14,12 @@ const { startsWithWindowsDriveLetter } = resolve
 const defaultExtensions = ['.js', '.cjs', '.mjs', '.ts', '.cts', '.mts', '.json', '.bare', '.node']
 const defaultConditions = ['bare', 'node', ...Bare.Addon.host.split('-')]
 const defaultCache = Object.create(null)
+const defaultResolutions = Object.create(null)
 
-const defaultProtocol = new ModuleProtocol({
-  postresolve(url) {
-    switch (url.protocol) {
-      case 'file:':
-        return pathToFileURL(binding.realpath(path.toNamespacedPath(fileURLToPath(url))))
-      default:
-        return url
-    }
-  },
-
-  exists(url, type = 0) {
-    switch (url.protocol) {
-      case 'file:':
-        return binding.exists(
-          path.toNamespacedPath(fileURLToPath(url)),
-          type === constants.types.ASSET ? binding.FILE | binding.DIR : binding.FILE
-        )
-      default:
-        return false
-    }
-  },
-
-  read(url) {
-    switch (url.protocol) {
-      case 'file:':
-        return Buffer.from(binding.read(path.toNamespacedPath(fileURLToPath(url))))
-      default:
-        throw errors.UNKNOWN_PROTOCOL(`Cannot load module '${url.href}'`)
-    }
-  }
-})
+// The default protocol has no capabilities of its own; in particular, it
+// cannot read from the file system. Embedders that wish to load modules from a
+// backing store, such as the file system, must provide their own protocol.
+const defaultProtocol = new ModuleProtocol()
 
 const defaultContext = new ModuleContext({
   defaultType: 0,
@@ -53,7 +27,7 @@ const defaultContext = new ModuleContext({
   protocol: defaultProtocol,
   cache: defaultCache,
   imports: null,
-  resolutions: Object.create(null),
+  resolutions: defaultResolutions,
   builtins: null,
   conditions: defaultConditions
 })
@@ -227,8 +201,8 @@ class Module {
       conditions = inherited.conditions
     } = opts
 
-    const cache = cacheFor(opts.cache, inherited.cache)
-    const resolutions = resolutionsFor(opts, inherited.resolutions)
+    const cache = cacheFor(opts.cache, referrer ? inherited.cache : undefined)
+    const resolutions = resolutionsFor(opts, referrer ? inherited.resolutions : undefined)
 
     let module = cache[url.href] || null
 
@@ -590,8 +564,8 @@ exports.createRequire = function createRequire(parentURL, opts = {}) {
     conditions = inherited.conditions
   } = opts
 
-  const cache = cacheFor(opts.cache, inherited.cache)
-  const resolutions = resolutionsFor(opts, inherited.resolutions)
+  const cache = cacheFor(opts.cache, opts.referrer ? inherited.cache : undefined)
+  const resolutions = resolutionsFor(opts, opts.referrer ? inherited.resolutions : undefined)
 
   let module = opts.module || null
 
@@ -673,15 +647,32 @@ function hasContextOverride(opts) {
 }
 
 function cacheFor(cache, fallback = Object.create(null)) {
+  // The shared default cache is opt-in; it is only used when explicitly
+  // requested with `cache: true`.
+  if (cache === true) return defaultCache
+
+  // A fresh cache is used when explicitly requested with `cache: false`.
   if (cache === false) return Object.create(null)
 
-  return cache === undefined || cache === true ? fallback : cache
+  // When left unspecified, the cache is inherited from the referrer so a
+  // module graph shares a single cache, falling back to a fresh one at the
+  // root of a graph.
+  if (cache === undefined) return fallback
+
+  return cache
 }
 
 function resolutionsFor(opts, fallback = Object.create(null)) {
   if (opts.resolutions !== undefined) return opts.resolutions
 
-  return opts.cache === undefined || opts.cache === true ? fallback : Object.create(null)
+  // Mirror the cache: resolutions live for as long as the cache they are paired
+  // with, so a shared cache shares its resolutions and a fresh cache gets fresh
+  // resolutions.
+  if (opts.cache === true) return defaultResolutions
+
+  if (opts.cache === undefined) return fallback
+
+  return Object.create(null)
 }
 
 function readPackageFor(protocol, cache) {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,4 @@
 const test = require('brittle')
-const { pathToFileURL } = require('bare-url')
 const Bundle = require('bare-bundle')
 const Module = require('.')
 
@@ -2822,10 +2821,6 @@ test('syntax error in .mjs imported from .mjs', (t) => {
   }
 })
 
-test('load file: URL using the default protocol', (t) => {
-  t.is(Module.load(pathToFileURL('test/fixtures/foo.js'), null, { cache: false }).exports, 42)
-})
-
 test('load non-file: URL using the default protocol', (t) => {
   t.is(Module.load(new URL('foo:/foo.js'), 'module.exports = 42', { cache: false }).exports, 42)
 })
@@ -2837,39 +2832,6 @@ test('load non-file: URL with missing import using the default protocol', (t) =>
   } catch (err) {
     t.comment(err.message)
   }
-})
-
-test('resolve file: asset URL using the default protocol', (t) => {
-  t.alike(
-    Module.asset('./test/fixtures/foo.js', pathToFileURL(__dirname + '/')),
-    pathToFileURL(__dirname + '/test/fixtures/foo.js')
-  )
-})
-
-test('resolve file: asset directory URL using the default protocol', (t) => {
-  t.alike(
-    Module.asset('./test/fixtures', pathToFileURL(__dirname + '/')),
-    pathToFileURL(__dirname + '/test/fixtures')
-  )
-})
-
-test('extend the default protocol', (t) => {
-  const protocol = Module.protocol.extend({
-    read(context, url) {
-      const buffer = context.read(url)
-
-      if (url.href.endsWith('/test/fixtures/bar.js')) {
-        return Buffer.from("module.exports = 'modified'")
-      }
-
-      return buffer
-    }
-  })
-
-  t.is(
-    Module.load(pathToFileURL('test/fixtures/foo.js'), { protocol, cache: false }).exports,
-    'modified'
-  )
 })
 
 test('load .js with asset import', (t) => {
@@ -3492,6 +3454,44 @@ test('load without cache', (t) => {
 
   const a = Module.load(new URL(root + '/index.cjs'), { protocol, cache: false })
   const b = Module.load(new URL(root + '/index.cjs'), { protocol, cache: false })
+
+  t.is(a.exports, 42)
+  t.is(b.exports, 42)
+  t.not(a, b)
+})
+
+test('load with the shared cache', (t) => {
+  const protocol = new Module.Protocol({
+    read(url) {
+      if (url.href === root + '/shared.cjs') {
+        return 'module.exports = 42'
+      }
+
+      t.fail()
+    }
+  })
+
+  const a = Module.load(new URL(root + '/shared.cjs'), { protocol, cache: true })
+  const b = Module.load(new URL(root + '/shared.cjs'), { protocol, cache: true })
+
+  t.is(a.exports, 42)
+  t.is(b.exports, 42)
+  t.is(a, b)
+})
+
+test('load without a cache does not use the shared cache', (t) => {
+  const protocol = new Module.Protocol({
+    read(url) {
+      if (url.href === root + '/index.cjs') {
+        return 'module.exports = 42'
+      }
+
+      t.fail()
+    }
+  })
+
+  const a = Module.load(new URL(root + '/index.cjs'), { protocol })
+  const b = Module.load(new URL(root + '/index.cjs'), { protocol })
 
   t.is(a.exports, 42)
   t.is(b.exports, 42)


### PR DESCRIPTION
This also makes the shared cache opt-in to prevent inadvertently exposing capabilities of modules already in the cache.