### PR TITLE
Update Bare requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/holepunchto/bare-module#readme",
   "engines": {
-    "bare": ">=1.30.0"
+    "bare": ">=1.31.0"
   },
   "dependencies": {
     "bare-bundle": "^1.3.0",


### PR DESCRIPTION
v7 will depend on the upcoming `new Bare.Addon()` and `js_compile_function()` APIs that I expect to release in v1.31.0.