### PR TITLE
Grant publish permissions to the publish job only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,7 @@ on:
     tags:
       - v*
 permissions:
-  id-token: write
-  contents: write
+  contents: read
 jobs:
   prebuild:
     strategy:
@@ -67,6 +66,9 @@ jobs:
           upload: true
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     environment:
       name: npm
     needs: prebuild


### PR DESCRIPTION
`id-token: write` and `contents: write` were declared at workflow level, so the build jobs inherited both. They compile from source and install packages from external mirrors, and they need neither - prebuilds move through artifacts.

The `npm` environment gate is on the `publish` job, and an OIDC grant does not respect it, so code running in a build job could mint a token outside it.

`publish` keeps both, since it needs the token to publish and `contents` to create the release.

This is not specific to this repo. It came from the workflow in holepunchto/repo-template, which shows no symptom itself because it has a single job - holepunchto/repo-template#7 fixes it there. Of the 154 bare repos running an Integrate workflow, 70 carry this exact pattern; this is one of them.

Same fix as holepunchto/bare-collabora#60 and holepunchto/bare-kit#110.
